### PR TITLE
Add appsettings config

### DIFF
--- a/ChefKnivesCommentsDatabase/ChefKnivesCommentsDatabase.csproj
+++ b/ChefKnivesCommentsDatabase/ChefKnivesCommentsDatabase.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/ChefKnivesCommentsDatabase/ChefKnivesCommentsDatabase.csproj
+++ b/ChefKnivesCommentsDatabase/ChefKnivesCommentsDatabase.csproj
@@ -2,10 +2,22 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
     <PackageReference Include="MongoDB.Bson" Version="2.11.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/ChefKnivesCommentsDatabase/Program.cs
+++ b/ChefKnivesCommentsDatabase/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Configuration;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,10 +13,21 @@ namespace ChefKnivesCommentsDatabase
         /// </summary>
         private static readonly TimeSpan cycleLength = TimeSpan.FromMinutes(30);
 
+        private static IConfigurationRoot _configuration;
+
         static void Main()
         {
+            var initialConfiguration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", false, true)
+                .Build();
+
+            _configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", false, true)
+                .AddJsonFile(initialConfiguration["SecretsFile"], false, true)
+                .Build();
+
             RedditHttpsReader redditReader = new RedditHttpsReader(subreddit: "chefknives");
-            using (RedditContentDatabase redditDatabase = new RedditContentDatabase(subreddit: "chefknives"))
+            using (RedditContentDatabase redditDatabase = new RedditContentDatabase(_configuration, subreddit: "chefknives"))
             {
                 while (true)
                 {

--- a/ChefKnivesCommentsDatabase/Program.cs
+++ b/ChefKnivesCommentsDatabase/Program.cs
@@ -18,12 +18,12 @@ namespace ChefKnivesCommentsDatabase
         static void Main()
         {
             var initialConfiguration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", false, true)
+                .AddJsonFile("appsettings.json", false, false)
                 .Build();
 
             _configuration = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", false, true)
-                .AddJsonFile(initialConfiguration["SecretsFile"], false, true)
+                .AddJsonFile(Environment.ExpandEnvironmentVariables(initialConfiguration["SecretsFile"]), true, false)
                 .Build();
 
             RedditHttpsReader redditReader = new RedditHttpsReader(subreddit: "chefknives");

--- a/ChefKnivesCommentsDatabase/RedditContentDatabase.cs
+++ b/ChefKnivesCommentsDatabase/RedditContentDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using ChefKnivesCommentsDatabase.Utility;
+using Microsoft.Extensions.Configuration;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using System;
@@ -9,15 +10,15 @@ namespace ChefKnivesCommentsDatabase
     public class RedditContentDatabase : IDisposable
     {
         private readonly string subreddit;
-        private static readonly string ConnectionString = Environment.GetEnvironmentVariable("connectionString");
-        private readonly MongoClient mongoClient = new MongoClient(ConnectionString);
+        private readonly MongoClient mongoClient;
         private const string commentsCollectionName = "comments";
         private const string postsCollectionName = "posts";
         private readonly DatabaseCache<RedditComment> commentCache = new DatabaseCache<RedditComment>(10000);
         private readonly DatabaseCache<RedditPost> postCache = new DatabaseCache<RedditPost>(1000);
 
-        public RedditContentDatabase(string subreddit)
+        public RedditContentDatabase(IConfiguration configuration, string subreddit)
         {
+            this.mongoClient = new MongoClient(configuration["ConnectionString"]);
             this.subreddit = subreddit;
             if (!mongoClient.GetDatabase(subreddit).ListCollections(new ListCollectionsOptions { Filter = new BsonDocument("name", commentsCollectionName) }).Any())
             {

--- a/ChefKnivesCommentsDatabase/appsettings.json
+++ b/ChefKnivesCommentsDatabase/appsettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "SecretsFile": "C:/Users/matth/Google Drive/ChefKnivesCommentsDatabaseSettings.json"
+}

--- a/ChefKnivesCommentsDatabase/appsettings.json
+++ b/ChefKnivesCommentsDatabase/appsettings.json
@@ -6,5 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "SecretsFile": "C:/Users/matth/Google Drive/ChefKnivesCommentsDatabaseSettings.json"
+  "SecretsFile": "%USERPROFILE%/AppData/Local/ChefKnives/ChefKnivesCommentsDatabaseSettings.json"
 }

--- a/ChefKnivesCommentsTest/ChefKnivesCommentsTest.csproj
+++ b/ChefKnivesCommentsTest/ChefKnivesCommentsTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ChefKnivesCommentsTest/ChefKnivesCommentsTest.csproj
+++ b/ChefKnivesCommentsTest/ChefKnivesCommentsTest.csproj
@@ -7,6 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/ChefKnivesCommentsTest/DatabaseTest.cs
+++ b/ChefKnivesCommentsTest/DatabaseTest.cs
@@ -23,16 +23,9 @@ namespace ChefKnivesCommentsTest
 
         public static IConfiguration GetTestConfiguration()
         {
-            var configurationDictionary = new Dictionary<string, string>
-            {
-                {"ConnectionString", "dummy connection string"},
-            };
-
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(configurationDictionary)
+            return new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", false, true)
                 .Build();
-
-            return configuration;
         }
     }
 

--- a/ChefKnivesCommentsTest/DatabaseTest.cs
+++ b/ChefKnivesCommentsTest/DatabaseTest.cs
@@ -1,4 +1,5 @@
 ﻿using ChefKnivesCommentsDatabase;
+using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -7,7 +8,8 @@ namespace ChefKnivesCommentsTest
 {
     internal class TestDatabase : RedditContentDatabase
     {
-        public TestDatabase(string subreddit) : base(subreddit) { }
+        public TestDatabase(string subreddit) 
+            : base(TestDatabase.GetTestConfiguration(), subreddit) { }
 
         protected override void UpsertIntoCollection(RedditComment comment)
         {
@@ -17,6 +19,20 @@ namespace ChefKnivesCommentsTest
         protected override void UpsertIntoCollection(RedditPost comment)
         {
             throw new Exception("UpsertIntoCollection was hit");
+        }
+
+        public static IConfiguration GetTestConfiguration()
+        {
+            var configurationDictionary = new Dictionary<string, string>
+            {
+                {"ConnectionString", "dummy connection string"},
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configurationDictionary)
+                .Build();
+
+            return configuration;
         }
     }
 

--- a/ChefKnivesCommentsTest/appsettings.json
+++ b/ChefKnivesCommentsTest/appsettings.json
@@ -1,0 +1,3 @@
+﻿{
+  "ConnectionString": "mongodb://localhost"
+}


### PR DESCRIPTION
- changed to .net core 3.1
- adds appsettings.json
- reads from appsettings.json, which then contains a path to a different file
- tries to load the second file

Either the first appsettings.json or the second file much contain ConnectionString for mongo. the files are compounded together so it will fail if both contain the same key I think. The use of the second file is to keep it out of source. By default, this will look for the second file in:

"%USERPROFILE%/AppData/Local/ChefKnives/ChefKnivesCommentsDatabaseSettings.json"